### PR TITLE
fix cuda cache

### DIFF
--- a/source/core/platform.cpp
+++ b/source/core/platform.cpp
@@ -161,8 +161,7 @@ const std::string Platform::syntacticSugar() const {
 const std::string Platform::cacheDecl(std::string name, int64_t cache_size,
                                       std::string datatype) const {
   switch (type) {
-    CASE(CUDA, datatype + " " + name + "[" + std::to_string(cache_size) +
-                   " / sizeof(" + datatype + ")];");
+    CASE(CUDA, "char " + name + "[" + std::to_string(cache_size) + "];");
     CASE(BANG,
          "__nram__ char " + name + "[" + std::to_string(cache_size) + "];");
     default:

--- a/source/micros/binary_micro.cpp
+++ b/source/micros/binary_micro.cpp
@@ -26,9 +26,7 @@ namespace infini {
         BangAllocateMicro(output_name, output, length, data_type)              \
             .generatorCode(cache, code, indent);                               \
     code += indentation(indent) + "__bang_" + std::string(OP_STRING) + "(" +   \
-            "(" + datatype_string(data_type) + " *)(" + output_cache + "), " + \
-            "(" + datatype_string(data_type) + " *)(" + left_cache + "), " +   \
-            "(" + datatype_string(data_type) + " *)(" + right_cache + "), " +  \
+            output_cache + ", " + left_cache + ", " + right_cache + ", " +     \
             std::to_string(length) + ");\n";                                   \
     cache.unlock();                                                            \
     return "";                                                                 \

--- a/source/micros/memory_micro.cpp
+++ b/source/micros/memory_micro.cpp
@@ -10,8 +10,9 @@ std::string BangLoadMicro::generatorCode(Cache &cache, std::string &code,
   CacheData cache_data = CacheData(data_name, data, length_in_bytes);
   auto result = cache.load(cache_data);
   std::string length_string = std::to_string(length_in_bytes);
-  std::string cache_string =
-      cache.name + " + " + std::to_string(result.cache_offset);
+  std::string cache_string = "(" + datatype_string(data_type) + " *)(" +
+                             cache.name + " + " +
+                             std::to_string(result.cache_offset) + ")";
   std::string data_string = data_name + " + " + std::to_string(data);
   data_string += " + " + core_index_name + " * " + std::to_string(length);
   std::string ldram_from_string =
@@ -53,8 +54,9 @@ std::string BangStoreMicro::generatorCode(Cache &cache, std::string &code,
   CacheData cache_data = CacheData(data_name, data, length_in_bytes);
   auto result = cache.find(cache_data);
   std::string length_string = std::to_string(length_in_bytes);
-  std::string cache_string =
-      cache.name + " + " + std::to_string(result.cache_offset);
+  std::string cache_string = "(" + datatype_string(data_type) + " *)(" +
+                             cache.name + " + " +
+                             std::to_string(result.cache_offset) + ")";
   std::string data_string = data_name + " + " + std::to_string(data);
   data_string += " + " + core_index_name + " * " + std::to_string(length);
   std::string ldram_from_string =
@@ -87,8 +89,9 @@ std::string BangAllocateMicro::generatorCode(Cache &cache, std::string &code,
   CacheData cache_data = CacheData(data_name, data, length_in_bytes);
   auto result = cache.allocate(cache_data);
   std::string length_string = std::to_string(length_in_bytes);
-  std::string cache_string =
-      cache.name + " + " + std::to_string(result.cache_offset);
+  std::string cache_string = "(" + datatype_string(data_type) + " *)(" +
+                             cache.name + " + " +
+                             std::to_string(result.cache_offset) + ")";
   std::string data_string = data_name + " + " + std::to_string(data);
   data_string += " + " + core_index_name + " * " + std::to_string(length);
   std::string ldram_from_string =
@@ -116,7 +119,7 @@ std::string CudaLoadMicro::generatorCode(Cache &cache, std::string &code,
   auto result = cache.load(cache_data);
   std::string length_string = std::to_string(length);
   std::string cache_string =
-      cache.name + "[" +
+      "((" + datatype_string(data_type) + "*)" + "(" + cache.name + "))" + "[" +
       std::to_string(result.cache_offset / datatype_size(data_type));
   std::string data_string = data_name + "[" + std::to_string(data) + " + ";
   data_string += core_index_name + " * " + length_string + " + ";
@@ -146,7 +149,7 @@ std::string CudaStoreMicro::generatorCode(Cache &cache, std::string &code,
   auto result = cache.find(cache_data);
   std::string length_string = std::to_string(length);
   std::string cache_string =
-      cache.name + "[" +
+      "((" + datatype_string(data_type) + "*)" + "(" + cache.name + "))" + "[" +
       std::to_string(result.cache_offset / datatype_size(data_type));
   std::string data_string = data_name + "[" + std::to_string(data) + " + ";
   data_string += core_index_name + " * " + length_string + " + ";
@@ -169,7 +172,7 @@ std::string CudaAllocateMicro::generatorCode(Cache &cache, std::string &code,
   auto result = cache.allocate(cache_data);
   std::string length_string = std::to_string(length);
   std::string cache_string =
-      cache.name + "[" +
+      "((" + datatype_string(data_type) + "*)" + "(" + cache.name + "))" + "[" +
       std::to_string(result.cache_offset / datatype_size(data_type));
   std::string data_string = data_name + "[" + std::to_string(data) + " + ";
   data_string += core_index_name + " * " + length_string + " + ";


### PR DESCRIPTION
1. 修改了cuda代码中cache数组的类型为char；
2. 修改了bang上cache相关的字符串拼接逻辑，将对cache进行类型转换的字符串写在memorymicro中而不是binarymicro中